### PR TITLE
Delete new frame after ending edit.

### DIFF
--- a/hammerspoon.el
+++ b/hammerspoon.el
@@ -99,7 +99,7 @@ If you see a message, Hammerspoon is working correctly."
   (mark-whole-buffer)
   (call-interactively 'kill-ring-save)
   (hammerspoon-do (concat "spoon.editWithEmacs:endEditing(False)"))
-  (previous-buffer))
+  (delete-frame (selected-frame))))
 
 (defun hammerspoon-edit-begin ()
   "Receive, from Hammerspoon, text to edit in Emacs"


### PR DESCRIPTION
As the default config creates a new frame
`obj.openEditorShellCommand = "emacsclient -e '(hammerspoon-edit-begin)' --create-frame -n"` after doing the changes I think it is best to delete the frame again.  This change is proposed in the PR.

In Doom Emacs, I tested the configuration, as follows:
```elisp
;; config.el
(load! "~/.hammerspoon/Spoons/editWithEmacs.spoon/hammerspoon.el")
(after! hammerspoon
  (defun hammerspoon-edit-end ()
    "Send, via Hammerspoon, contents of buffer back to originating window."
    (interactive)
    (mark-whole-buffer)
    (call-interactively 'kill-ring-save)
    (hammerspoon-do (concat "spoon.editWithEmacs:endEditing(False)"))
    (delete-frame (selected-frame)))
)
```